### PR TITLE
Add NuGet packaging configuration and publish workflow

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,0 +1,49 @@
+name: Publish to NuGet
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 1.0.0)'
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '10.0.x'
+    
+    - name: Set version from release tag
+      if: github.event_name == 'release'
+      run: |
+        VERSION=${GITHUB_REF#refs/tags/v}
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+    
+    - name: Set version from input
+      if: github.event_name == 'workflow_dispatch'
+      run: |
+        echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+    
+    - name: Update version in csproj
+      run: |
+        sed -i "s|<Version>.*</Version>|<Version>$VERSION</Version>|" squad-monitor.csproj
+    
+    - name: Restore dependencies
+      run: dotnet restore
+    
+    - name: Build
+      run: dotnet build -c Release --no-restore
+    
+    - name: Pack
+      run: dotnet pack -c Release --no-build --output ./nupkg
+    
+    - name: Publish to NuGet
+      run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/README.md
+++ b/README.md
@@ -19,20 +19,43 @@ Live terminal dashboard for monitoring AI agent orchestration. See what your Cop
 
 ## Quick Start
 
+### Installation
+
+#### Option 1: Install as .NET Global Tool (Recommended)
+
+```bash
+dotnet tool install -g squad-monitor
+```
+
+Then run from anywhere:
+
+```bash
+squad-monitor
+```
+
+To update:
+
+```bash
+dotnet tool update -g squad-monitor
+```
+
+#### Option 2: Build from Source
+
+```bash
+git clone https://github.com/tamirdresher/squad-monitor.git
+cd squad-monitor
+dotnet run
+```
+
 ### Prerequisites
 
 - [.NET 10 SDK](https://dotnet.microsoft.com/download)
 - [GitHub CLI](https://cli.github.com/) (`gh`) — authenticated via `gh auth login`
 - A `.squad/` directory in your repo (created by the Squad orchestrator)
 
-### Build & Run
-
-```bash
-cd squad-monitor
-dotnet run
-```
-
 ### Options
+
+When running `squad-monitor` (either as a global tool or via `dotnet run`):
 
 | Flag | Description |
 |------|-------------|

--- a/squad-monitor.csproj
+++ b/squad-monitor.csproj
@@ -7,10 +7,24 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>13.0</LangVersion>
-    <PublishSingleFile>true</PublishSingleFile>
-    <SelfContained>true</SelfContained>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    
+    <!-- NuGet Tool Package Configuration -->
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>squad-monitor</ToolCommandName>
+    <PackageId>squad-monitor</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>Tamir Dresher</Authors>
+    <Description>Live terminal dashboard for monitoring AI agent orchestration. See what your Copilot agents and sub-agents are doing in real-time.</Description>
+    <PackageTags>copilot;agents;monitoring;dashboard;cli</PackageTags>
+    <PackageProjectUrl>https://github.com/tamirdresher/squad-monitor</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/tamirdresher/squad-monitor</RepositoryUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Spectre.Console" Version="0.49.1" />


### PR DESCRIPTION
This PR adds NuGet packaging configuration to publish squad-monitor as a .NET tool.

Changes:
- Configured squad-monitor.csproj as a tool package (PackAsTool)
- Set tool command name to 'squad-monitor'
- Added package metadata (description, tags, license)
- Included README in package
- Added GitHub Actions workflow for automated publishing to NuGet

After merging, the package can be published by:
1. Creating a release on GitHub (triggers automatic publish)
2. Manually triggering the workflow with a version number

Note: NUGET_API_KEY secret must be configured in repository settings for publishing to work.

Closes #265